### PR TITLE
Don't monitor /dev/sda15 which is used for boot partition on azure vm

### DIFF
--- a/plans/datadog-monitors.tf
+++ b/plans/datadog-monitors.tf
@@ -88,7 +88,7 @@ resource "datadog_monitor" "disk_space" {
   type               = "query alert"
   message            = "@pagerduty"
 
-  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:/dev/vda1,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!device:/dev/sda15} by {host,device} < 1073741824"
+  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!device:/dev/sda15} by {host,device} < 1073741824"
 
   locked              = false
   include_tags        = false

--- a/plans/datadog-monitors.tf
+++ b/plans/datadog-monitors.tf
@@ -88,7 +88,7 @@ resource "datadog_monitor" "disk_space" {
   type               = "query alert"
   message            = "@pagerduty"
 
-  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:/dev/vda1,!device:cgroup,!device:udev,!device:shm,!device:cgmfs} by {host,device} < 1073741824"
+  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:/dev/vda1,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!device:/dev/sda15} by {host,device} < 1073741824"
 
   locked              = false
   include_tags        = false


### PR DESCRIPTION
Azure VM use by default a boot partition on /dev/sda15, which trigger datadog alert, I had to manually mute that checks but I think it safer to just disable monitoring for that partition, the probability that this partition is used for any others things than boot is pretty down to zero  

** EDIT **
I also reenable /dev/vda1 partition used by lettuce and radish, which for an unknown reason was explictiely not monitored