### PR TITLE
Require docker&&linux

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env groovy
 
 pipeline {
-  agent { label 'docker' }
+  agent { label 'docker&&linux' }
 
   options {
       buildDiscarder(logRotator(numToKeepStr: '10'))


### PR DESCRIPTION
Windows docker agents will be coming up soon, make sure we only run this on Linux docker agents.