### PR TITLE
Don't monitor loop device

### DIFF
--- a/plans/datadog-monitors.tf
+++ b/plans/datadog-monitors.tf
@@ -88,7 +88,7 @@ resource "datadog_monitor" "disk_space" {
   type               = "query alert"
   message            = "@pagerduty"
 
-  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!device:/dev/sda15} by {host,device} < 1073741824"
+  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!device:/dev/sda15,!device:/dev/loop*} by {host,device} < 1073741824"
 
   locked              = false
   include_tags        = false


### PR DESCRIPTION
It doesn't make sense to trigger disk space issues on those devices as they will always flag as 100% disk space used.

Signed-off-by: Olivier Vernin <olivier@vernin.me>