### PR TITLE
breaking: bump terraform to 1.0.4 + all required dependencies

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -30,31 +30,41 @@ pipeline {
     stage('Terraform') {
       parallel {
         stage('Production') {
-          stage('Plan') {
-            steps {
-              sh '''
-              make init
-              make plan
-              '''
+          stages {
+            stage('Plan') {
+              steps {
+                sh '''
+                make init
+                make plan
+                '''
+              }
             }
-          }
-          stage('Apply') {
-            when {
-              branch 'main'
-            }
-            steps {
-              sh 'make apply'
+            stage('Apply') {
+              when {
+                branch 'main'
+              }
+              steps {
+                sh 'make apply'
+              }
             }
           }
         }
         stage('UpdateCLI') {
-          steps {
-            script {
-              withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
+          environment {
+            UPDATECLI_GITHUB_TOKEN = credentials('updatecli-github-token')
+          }
+          stages {
+            stage('UpdateCLI - Diff') {
+              steps {
                 updatecli(action: 'diff')
-                if (env.BRANCH_NAME == 'main') {
-                  updatecli(action: 'apply', cronTriggerExpression: '@daily')
-                }
+              }
+            }
+            stage('UpdateCLI - Apply') {
+              when {
+                branch 'main'
+              }
+              steps {
+                updatecli(action: 'apply', cronTriggerExpression: '@daily')
               }
             }
           }

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -27,20 +27,38 @@ pipeline {
   }
 
   stages {
-    stage('Plan') {
-      steps {
-        sh '''
-        make init
-        make plan
-        '''
-      }
-    }
-    stage('Apply') {
-      when {
-        branch 'main'
-      }
-      steps {
-        sh 'make apply'
+    stage('Terraform') {
+      parallel {
+        stage('Production') {
+          stage('Plan') {
+            steps {
+              sh '''
+              make init
+              make plan
+              '''
+            }
+          }
+          stage('Apply') {
+            when {
+              branch 'main'
+            }
+            steps {
+              sh 'make apply'
+            }
+          }
+        }
+        stage('UpdateCLI') {
+          steps {
+            script {
+              withCredentials([string(credentialsId: 'updatecli-github-token', variable: 'UPDATECLI_GITHUB_TOKEN')]) {
+                updatecli(action: 'diff')
+                if (env.BRANCH_NAME == 'main') {
+                  updatecli(action: 'apply', cronTriggerExpression: '@daily')
+                }
+              }
+            }
+          }
+        }
       }
     }
   }

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 TERRAFORM_BIN ?= terraform
+TERRAFORM_GLOBAL_OPTS ?= -chdir=./plans
 PLAN ?= terraform-plan.out
 
 all: clean plan apply
@@ -9,18 +10,18 @@ clean:
 init: .terraform/plugins/selections.json
 
 validate: .terraform/plugins/selections.json
-	terraform fmt -recursive -check
-	$(TERRAFORM_BIN) validate plans
+	$(TERRAFORM_BIN) $(TERRAFORM_GLOBAL_OPTS) fmt -recursive -check
+	$(TERRAFORM_BIN) $(TERRAFORM_GLOBAL_OPTS) validate
 	tfsec --exclude-downloaded-modules
 
 plan: .terraform/plugins/selections.json
-	$(TERRAFORM_BIN) plan -out=$(PLAN) plans
+	$(TERRAFORM_BIN) $(TERRAFORM_GLOBAL_OPTS) plan -out=$(PLAN)
 
 apply: .terraform/plugins/selections.json
-	$(TERRAFORM_BIN) apply -auto-approve=true $(PLAN)
+	$(TERRAFORM_BIN) $(TERRAFORM_GLOBAL_OPTS) apply -auto-approve=true $(PLAN)
 
 destroy:
-	$(TERRAFORM_BIN) destroy -auto-approve=true plans
+	$(TERRAFORM_BIN) $(TERRAFORM_GLOBAL_OPTS) destroy -auto-approve=true
 
 .PHONY: apply clean destroy init plan validate
 
@@ -29,10 +30,9 @@ destroy:
 	if [ -f 'credentials' ]; then\
 		source ./credentials ;\
 	fi; \
-	$(TERRAFORM_BIN) init \
+	$(TERRAFORM_BIN) $(TERRAFORM_GLOBAL_OPTS) init \
 		-backend-config="storage_account_name=$$TF_BACKEND_STORAGE_ACCOUNT_NAME" \
 		-backend-config="container_name=$$TF_BACKEND_CONTAINER_NAME" \
 		-backend-config="key=$$TF_BACKEND_CONTAINER_FILE" \
 		-backend-config="access_key=$$TF_BACKEND_STORAGE_ACCOUNT_KEY" \
-		-force-copy \
-		plans
+		-force-copy

--- a/ci-pod-template.yml
+++ b/ci-pod-template.yml
@@ -1,12 +1,10 @@
----
 apiVersion: v1
 kind: Pod
 spec:
   automountServiceAccountToken: false
   containers:
-  - name: terraform
-    image: jenkinsciinfra/terraform:1.3.12
-    command:
-    - cat
-    tty: true
-...
+    - name: terraform
+      image: jenkinsciinfra/terraform:1.4.2
+      command:
+        - cat
+      tty: true

--- a/plans/.terraform.lock.hcl
+++ b/plans/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/datadog/datadog" {
+  version     = "3.2.0"
+  constraints = "~> 3.2"
+  hashes = [
+    "h1:nfbkvIrUHhsI0cx7IfYDdwdn+C7nBaDvqp3lsZ2BcQw=",
+    "zh:0973526974954263941cc4bc4a4bbd5a56726c09ebd118a513b0106d2164863d",
+    "zh:0e89a0254f65951da832f73822592c46758e168a1ea3f7fa7eb6c79fe1e13a5d",
+    "zh:35145207a6b585e51775079eb6c114d7d555c4f8a928361915374cb28b2cbe46",
+    "zh:3fdf4e1d184fbad0aed31e851cd8465d9be9e7481fcfcd1b5c0da7a1eb582048",
+    "zh:42dfbf4ecd8779346fa4764ce9db99b993fe3c8aefb6eea32d293f9a0bc5cab0",
+    "zh:4e172436bdcbfb2e41fa43a58bc89a1d1e47178e7011d99ff87885c65ef3966c",
+    "zh:72d77a750399ec7ff51c38894d54e54c178f16aab726b36caf0094501124f918",
+    "zh:72e112c8d008418f40677533e855a8b79061892fb42b8296ea69e8246d6205f9",
+    "zh:753d154fb6fb32f064469d3a2e2c657b7d8d19c674189480dae2d2f3b93d524b",
+    "zh:b8dfdcc4402856c043a08e4befe39b042203d616ffb370b54c64a7b3def6ca55",
+    "zh:be523a10cb95220cb52375ac71e03d8f0f48b0d8f3534075aa22d37b5d335d86",
+    "zh:eb9f11a30d9303b422eea27b5d11a716a290c81b8c09e5457292fb378386f66c",
+    "zh:fce91b84c90ce97b7acc6e4ec2cb6f9f4518ae070e00d7ca8973edd585d0ea14",
+  ]
+}

--- a/plans/main.tf
+++ b/plans/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 0.13.6, < 0.14.0"
+  required_version = ">= 1.0, < 1.1"
 
   required_providers {
     datadog = {
       source  = "DataDog/datadog"
-      version = "~> 2.25"
+      version = "~> 3.2"
     }
   }
 }

--- a/updatecli/updatecli.d/ciPodTemplate.yml
+++ b/updatecli/updatecli.d/ciPodTemplate.yml
@@ -1,0 +1,44 @@
+title: Bump Docker images of ci-pod-template.yml
+sources:
+  dockerTerraformImageVersion:
+    kind: githubRelease
+    spec:
+      owner: "jenkins-infra"
+      repository: "docker-terraform"
+      token: "{{ requiredEnv .github.token }}"
+      username: "{{ .github.username }}"
+conditions:
+  isContainerTerraformDefined:
+    name: "Is there a container named 'terraform' defined as the first container?"
+    kind: yaml
+    spec:
+      file: "ci-pod-template.yml"
+      key: spec.containers[0].name
+      value: terraform
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"
+targets:
+  updateImageOnPodTemplateForTerraform:
+    name: "Update the value of the key 'image' of the first container ('terraform')"
+    kind: yaml
+    transformers:
+      - addPrefix: "jenkinsciinfra/terraform:"
+    spec:
+      file: "ci-pod-template.yml"
+      key: spec.containers[0].image
+    scm:
+      github:
+        user: "{{ .github.user }}"
+        email: "{{ .github.email }}"
+        owner: "{{ .github.owner }}"
+        repository: "{{ .github.repository }}"
+        token: "{{ requiredEnv .github.token }}"
+        username: "{{ .github.username }}"
+        branch: "{{ .github.branch }}"

--- a/updatecli/values.yaml
+++ b/updatecli/values.yaml
@@ -1,0 +1,8 @@
+github:
+  user: "updatebot"
+  email: "updatebot@olblak.com"
+  username: "jenkins-infra-bot"
+  token: "UPDATECLI_GITHUB_TOKEN"
+  branch: "main"
+  owner: "jenkins-infra"
+  repository: "aws"


### PR DESCRIPTION
This PR updates the repository to support Terraform 1.0.

It includes the following changes:

- Bump Datadog provider to [3.2.0](https://github.com/DataDog/terraform-provider-datadog/releases/tag/v3.2.0) (from [2.25](https://github.com/DataDog/terraform-provider-datadog/compare/v2.25.0...v3.2.0)) to avoid using deprecated or unavailable syntax from terraform <0.12
- Breaking: Update the `Makefile` to use the new Terraform 1.x CLI flag `-cli` used to change working directory.
  * Because of this change, this PR requires https://github.com/jenkins-infra/docker-terraform/pull/49 to be merged and release (to be sure that Terraform 1.x is used with the CLI flag).
  * That's why the terraform project had been constrained to the Terraform version 1.0.x
- Add a [terraform lock file](https://www.terraform.io/docs/language/dependency-lock.html) to ensure tht the datadog dependency is fixed