### PR TITLE
fix(monitors:disk) exclude 'UEFI' and 'uefi' labels instead of named devices

### DIFF
--- a/plans/datadog-monitors.tf
+++ b/plans/datadog-monitors.tf
@@ -25,7 +25,7 @@ resource "datadog_monitor" "disk_space" {
   type    = "query alert"
   message = "@pagerduty"
 
-  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!device:/dev/sda15,!device:/dev/loop*} by {host,device} < 1073741824"
+  query = "max(last_5m):min:system.disk.free{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device} < 1073741824"
 
   locked              = false
   include_tags        = false


### PR DESCRIPTION
The datadog monitor for the available free disk space triggers alerts when less than 1Gb is available.

For some machine, the UEFI boot device is triggering the alert because it's usually sized at 100Mb, even though it's 99% free.

<img width="1861" alt="Capture d’écran 2021-11-04 à 07 53 37" src="https://user-images.githubusercontent.com/1522731/140270342-675e12ac-ca67-4689-8aef-c4e67597c486.png">

This PR filters out these devices by disk label instead of device adress:
- Device adress can change on reboot (happened to ci.jenkins.io VM)
- UUID would be a pain to maintain