### PR TITLE
fix: convert browser type to api

### DIFF
--- a/synthetics_accountApp.tf
+++ b/synthetics_accountApp.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "accountsApp" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://accounts.jenkins.io"
@@ -18,13 +18,6 @@ resource "datadog_synthetics_test" "accountsApp" {
   tags = [
     "jenkins.io",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_archives.tf
+++ b/synthetics_archives.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "archives_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://archives.jenkins.io"
@@ -20,18 +20,11 @@ resource "datadog_synthetics_test" "archives_jenkins_io" {
     "production"
   ]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
-  ]
-
   status = "live"
 }
 
 resource "datadog_synthetics_test" "archives_jenkinsci_org" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://archives.jenkins-ci.org"
@@ -50,13 +43,6 @@ resource "datadog_synthetics_test" "archives_jenkinsci_org" {
   tags = [
     "jenkins-ci.org",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_cijenkinsio.tf
+++ b/synthetics_cijenkinsio.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "cijenkinsio" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://ci.jenkins.io"
@@ -19,10 +19,4 @@ resource "datadog_synthetics_test" "cijenkinsio" {
 
   status = "live"
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
-  ]
 }

--- a/synthetics_issues.tf
+++ b/synthetics_issues.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "issuesjenkinsio" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://issues.jenkins.io/status"
@@ -17,17 +17,11 @@ resource "datadog_synthetics_test" "issuesjenkinsio" {
   message = "Notify @pagerduty"
   tags    = ["production", "jenkins.io"]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-  ]
-
   status = "live"
 }
 
 resource "datadog_synthetics_test" "issuesjenkinsciorg" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://issues.jenkins-ci.org/status"
@@ -49,12 +43,6 @@ resource "datadog_synthetics_test" "issuesjenkinsciorg" {
   name    = "issues.jenkins-ci.org"
   message = "Notify @pagerduty"
   tags    = ["production", "jenkins-ci.org"]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-  ]
 
   status = "live"
 }

--- a/synthetics_javadoc.tf
+++ b/synthetics_javadoc.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "javadoc_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://javadoc.jenkins.io"
@@ -20,18 +20,11 @@ resource "datadog_synthetics_test" "javadoc_jenkins_io" {
     "production"
   ]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
-  ]
-
   status = "live"
 }
 
 resource "datadog_synthetics_test" "javadoc_jenkinsci_org" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://javadoc.jenkins-ci.org"
@@ -50,13 +43,6 @@ resource "datadog_synthetics_test" "javadoc_jenkinsci_org" {
   tags = [
     "jenkins-ci.org",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_jenkinsio.tf
+++ b/synthetics_jenkinsio.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "jenkinsio" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://jenkins.io"
@@ -18,9 +18,5 @@ resource "datadog_synthetics_test" "jenkinsio" {
   tags    = ["production", "jenkins.io"]
 
   status = "live"
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-  ]
+
 }

--- a/synthetics_mirrors.tf
+++ b/synthetics_mirrors.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "mirrors_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "http://mirrors.jenkins.io"
@@ -20,18 +20,11 @@ resource "datadog_synthetics_test" "mirrors_jenkins_io" {
     "production"
   ]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
-  ]
-
   status = "live"
 }
 
 resource "datadog_synthetics_test" "mirrors_jenkinsci_org" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "http://mirrors.jenkins-ci.org"
@@ -50,13 +43,6 @@ resource "datadog_synthetics_test" "mirrors_jenkinsci_org" {
   tags = [
     "jenkins-ci.org",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_pkg.tf
+++ b/synthetics_pkg.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "pkg_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://pkg.origin.jenkins.io"
@@ -20,19 +20,12 @@ resource "datadog_synthetics_test" "pkg_jenkins_io" {
     "production"
   ]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
-  ]
-
   status = "live"
 }
 
 ## Do not monitor https
 resource "datadog_synthetics_test" "pkg_jenkinsci_org" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "http://pkg.jenkins-ci.org"
@@ -51,13 +44,6 @@ resource "datadog_synthetics_test" "pkg_jenkinsci_org" {
   tags = [
     "jenkins-ci.org",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_pluginsite.tf
+++ b/synthetics_pluginsite.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "plugins_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://plugins.jenkins.io"
@@ -18,13 +18,6 @@ resource "datadog_synthetics_test" "plugins_jenkins_io" {
   tags = [
     "jenkins.io",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_repo_ui.tf
+++ b/synthetics_repo_ui.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "repojenkinsciorgui" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://repo.jenkins-ci.org/ui"
@@ -19,9 +19,4 @@ resource "datadog_synthetics_test" "repojenkinsciorgui" {
 
   status = "live"
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-  ]
 }

--- a/synthetics_updatecenter.tf
+++ b/synthetics_updatecenter.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "updates_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://updates.jenkins.io"
@@ -20,18 +20,11 @@ resource "datadog_synthetics_test" "updates_jenkins_io" {
     "production"
   ]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
-  ]
-
   status = "live"
 }
 
 resource "datadog_synthetics_test" "updates_jenkinsci_org" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://updates.jenkins-ci.org"
@@ -50,13 +43,6 @@ resource "datadog_synthetics_test" "updates_jenkinsci_org" {
   tags = [
     "jenkins-ci.org",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"

--- a/synthetics_uplink.tf
+++ b/synthetics_uplink.tf
@@ -1,5 +1,5 @@
 resource "datadog_synthetics_test" "uplink_jenkins_io" {
-  type = "browser"
+  type = "api"
   request_definition {
     method = "GET"
     url    = "https://uplink.jenkins.io"
@@ -18,13 +18,6 @@ resource "datadog_synthetics_test" "uplink_jenkins_io" {
   tags = [
     "jenkins.io",
     "production"
-  ]
-
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
-
   ]
 
   status = "live"


### PR DESCRIPTION
as per https://github.com/jenkins-infra/helpdesk/issues/2923

⚠️  This PR should be merged only just after a manual delete of the actual checks within datadog UI.