### PR TITLE
correct url for jenkins.io for 200

### DIFF
--- a/synthetics_jenkinsio.tf
+++ b/synthetics_jenkinsio.tf
@@ -2,7 +2,7 @@ resource "datadog_synthetics_test" "jenkinsio" {
   type = "api"
   request_definition {
     method = "GET"
-    url    = "https://jenkins.io"
+    url    = "https://www.jenkins.io"
   }
   assertion {
     type     = "statusCode"


### PR DESCRIPTION
following https://github.com/jenkins-infra/datadog/pull/77 as it's now working we have alert on redirections 301.