### PR TITLE
feat(mirrors,get) monitor http to https enforced redirection and use the same pattern for get and mirrors

### DIFF
--- a/synthetics_get.tf
+++ b/synthetics_get.tf
@@ -27,7 +27,7 @@ resource "datadog_synthetics_test" "get_jenkins_io_enforced_https" {
   type = "api"
   request_definition {
     method = "GET"
-    url    = "http://get.jenkins-ci.org"
+    url    = "http://get.jenkins.io"
   }
   assertion {
     type     = "statusCode"
@@ -38,7 +38,7 @@ resource "datadog_synthetics_test" "get_jenkins_io_enforced_https" {
     type     = "header"
     property = "location"
     operator = "is"
-    target   = "https://get.jenkins-ci.org"
+    target   = "https://get.jenkins.io"
   }
   locations = ["aws:eu-central-1"]
   options_list {

--- a/synthetics_get.tf
+++ b/synthetics_get.tf
@@ -20,11 +20,35 @@ resource "datadog_synthetics_test" "get_jenkins_io" {
     "production"
   ]
 
-  device_ids = [
-    "laptop_large",
-    "tablet",
-    "mobile_small"
+  status = "live"
+}
 
+resource "datadog_synthetics_test" "get_jenkins_io_enforced_https" {
+  type = "api"
+  request_definition {
+    method = "GET"
+    url    = "http://get.jenkins-ci.org"
+  }
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "308"
+  }
+  assertion {
+    type     = "header"
+    property = "location"
+    operator = "is"
+    target   = "https://get.jenkins-ci.org"
+  }
+  locations = ["aws:eu-central-1"]
+  options_list {
+    tick_every = 900
+  }
+  name    = "get.jenkins.io-enforced-http"
+  message = "Notify @pagerduty"
+  tags = [
+    "jenkins.io",
+    "production"
   ]
 
   status = "live"

--- a/synthetics_mirrors.tf
+++ b/synthetics_mirrors.tf
@@ -2,7 +2,7 @@ resource "datadog_synthetics_test" "mirrors_jenkins_io" {
   type = "api"
   request_definition {
     method = "GET"
-    url    = "https://mirrors.jenkins.io"
+    url    = "https://mirrors.jenkins.io/debian/jenkins_2.251_all.deb?mirrorlist"
   }
   assertion {
     type     = "statusCode"
@@ -23,11 +23,42 @@ resource "datadog_synthetics_test" "mirrors_jenkins_io" {
   status = "live"
 }
 
+resource "datadog_synthetics_test" "mirrors_jenkins_io_enforced_https" {
+  type = "api"
+  request_definition {
+    method = "GET"
+    url    = "http://mirrors.jenkins.io"
+  }
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "308"
+  }
+  assertion {
+    type     = "header"
+    property = "location"
+    operator = "is"
+    target   = "https://mirrors.jenkins.io"
+  }
+  locations = ["aws:eu-central-1"]
+  options_list {
+    tick_every = 900
+  }
+  name    = "mirrors.jenkins.io-enforced-http"
+  message = "Notify @pagerduty"
+  tags = [
+    "jenkins.io",
+    "production"
+  ]
+
+  status = "live"
+}
+
 resource "datadog_synthetics_test" "mirrors_jenkinsci_org" {
   type = "api"
   request_definition {
     method = "GET"
-    url    = "https://mirrors.jenkins-ci.org"
+    url    = "https://mirrors.jenkins-ci.org/debian/jenkins_2.251_all.deb?mirrorlist"
   }
   assertion {
     type     = "statusCode"
@@ -39,6 +70,37 @@ resource "datadog_synthetics_test" "mirrors_jenkinsci_org" {
     tick_every = 900
   }
   name    = "mirrors.jenkins-ci.org"
+  message = "Notify @pagerduty"
+  tags = [
+    "jenkins-ci.org",
+    "production"
+  ]
+
+  status = "live"
+}
+
+resource "datadog_synthetics_test" "mirrors_jenkinsci_org_enforced_https" {
+  type = "api"
+  request_definition {
+    method = "GET"
+    url    = "http://mirrors.jenkins-ci.org"
+  }
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "308"
+  }
+  assertion {
+    type     = "header"
+    property = "location"
+    operator = "is"
+    target   = "https://mirrors.jenkins-ci.org"
+  }
+  locations = ["aws:eu-central-1"]
+  options_list {
+    tick_every = 900
+  }
+  name    = "mirrors.jenkins-ci.org-enforced-http"
   message = "Notify @pagerduty"
   tags = [
     "jenkins-ci.org",

--- a/synthetics_wiki.tf
+++ b/synthetics_wiki.tf
@@ -32,7 +32,7 @@ resource "datadog_synthetics_test" "wikijenkins_ciorg" {
     operator = "is"
     target   = "200"
   }
-  
+
   locations = ["aws:eu-central-1"]
   # Can't work at the moment according datadog message
   # Synthetics is only available for the Datadog US site.


### PR DESCRIPTION
Why this change? https://github.com/jenkins-infra/datadog/pull/85#discussion_r883476033

The goal is to monitor the enforced HTTP to HTTPS redirection introduced by the actions in https://github.com/jenkins-infra/helpdesk/issues/2888 (consildating the DNS mirrors.jenkins* to the kubernetes-hosted mirrorbits service, same as get.jenkins.io).