### PR TITLE
feat: add synthetic monitoring on artifact-caching-proxy providers

### DIFF
--- a/synthetics_accountapp_login.tf
+++ b/synthetics_accountapp_login.tf
@@ -6,7 +6,7 @@ resource "datadog_synthetics_test" "accountapp-login" {
     body   = "userid=datadog_monitoring&password=${var.datadog_jenkinsuser_password}"
   }
   request_headers = {
-    Content-Type   = "application/x-www-form-urlencoded"
+    Content-Type = "application/x-www-form-urlencoded"
   }
   assertion {
     type     = "statusCode"

--- a/synthetics_artifact-caching-proxy-providers.tf
+++ b/synthetics_artifact-caching-proxy-providers.tf
@@ -1,0 +1,25 @@
+resource "datadog_synthetics_test" "artifact-caching-proxy-providers" {
+  for_each = toset(var.artifact_caching_proxy_providers)
+  type     = "api"
+  request_definition {
+    method = "GET"
+    url    = "https://repo.${each.value}.jenkins.io/healthz"
+  }
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
+  }
+  locations = ["aws:eu-central-1"]
+  options_list {
+    tick_every = 900
+  }
+  name    = "repo.${each.value}.jenkins.io"
+  message = "Notify @pagerduty"
+  tags = [
+    "jenkins.io",
+    "production"
+  ]
+
+  status = "live"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,8 @@
 variable "datadog_api_key" {}
 variable "datadog_app_key" {}
 variable "datadog_jenkinsuser_password" {}
+variable "artifact_caching_proxy_providers" {
+  description = "Available artifact-caching-proxy providers"
+  type        = list(string)
+  default     = ["azure", "do"] # Omiting "aws" for now
+}


### PR DESCRIPTION
I've put aside the `aws` provider as it's out of service right now.

Ref: https://github.com/jenkins-infra/helpdesk/issues/3203 & https://github.com/jenkins-infra/helpdesk/issues/2752