### PR TITLE
chore: restore 'aws' artifact caching proxy provider

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -4,5 +4,5 @@ variable "datadog_jenkinsuser_password" {}
 variable "artifact_caching_proxy_providers" {
   description = "Available artifact-caching-proxy providers"
   type        = list(string)
-  default     = ["azure", "do"] # Omiting "aws" for now
+  default     = ["aws", "azure", "do"]
 }


### PR DESCRIPTION
The 'aws' artifact caching proxy is up now.