### PR TITLE
fixup: add missing scheme to plugin-health-scoring URL

### DIFF
--- a/synthetics_plugin-health-scoring.tf
+++ b/synthetics_plugin-health-scoring.tf
@@ -2,7 +2,7 @@ resource "datadog_synthetics_test" "plugin_health_scoring" {
   type = "api"
   request_definition {
     method = "GET"
-    url    = "plugin-health.jenkins.io"
+    url    = "https://plugin-health.jenkins.io"
   }
   assertion {
     type     = "statusCode"


### PR DESCRIPTION
Fixup of https://github.com/jenkins-infra/datadog/pull/128