### PR TITLE
fixup: plugin-health-scoring is returning a redirect at its root

### DIFF
--- a/synthetics_plugin-health-scoring.tf
+++ b/synthetics_plugin-health-scoring.tf
@@ -7,7 +7,7 @@ resource "datadog_synthetics_test" "plugin_health_scoring" {
   assertion {
     type     = "statusCode"
     operator = "is"
-    target   = "200"
+    target   = "302"
   }
   locations = ["aws:eu-central-1"]
   options_list {


### PR DESCRIPTION
Fixup of #128