### PR TITLE
fix(artifact-caching-proxy): new `health` URL

### DIFF
--- a/synthetics_artifact-caching-proxy-providers.tf
+++ b/synthetics_artifact-caching-proxy-providers.tf
@@ -3,7 +3,7 @@ resource "datadog_synthetics_test" "artifact-caching-proxy-providers" {
   type     = "api"
   request_definition {
     method = "GET"
-    url    = "https://repo.${each.value}.jenkins.io/healthz"
+    url    = "https://repo.${each.value}.jenkins.io/health"
   }
   assertion {
     type     = "statusCode"


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/kubernetes-management/pull/3537