### PR TITLE
feat: retry twice before alerting on `plugins.jenkins.io` and `www.jenkins.io`

### DIFF
--- a/synthetics_jenkinsio.tf
+++ b/synthetics_jenkinsio.tf
@@ -12,6 +12,11 @@ resource "datadog_synthetics_test" "jenkinsio" {
   locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
+    
+    retry {
+      count    = 2
+      interval = 300
+    }
   }
   name    = "jenkins.io"
   message = "Notify @pagerduty"

--- a/synthetics_pluginsite.tf
+++ b/synthetics_pluginsite.tf
@@ -12,6 +12,11 @@ resource "datadog_synthetics_test" "plugins_jenkins_io" {
   locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
+
+    retry {
+      count    = 2
+      interval = 300
+    }
   }
   name    = "plugins.jenkins.io"
   message = "Notify @pagerduty"


### PR DESCRIPTION
We've got frequent false alerts on these two website, this PR adds a retry which hopefully will resolve them.