### PR TITLE
feat(disk monitor) utilizes the system.disk.in_use fraction to simplify formula and avoid false positives

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -24,7 +24,7 @@ resource "datadog_monitor" "disk_space" {
   type    = "query alert"
   message = "{{^is_warning}}@pagerduty{{/is_warning}}"
 
-  query               = "avg(last_5m):exclude_null(avg:system.disk.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) > 0.9"
+  query               = "avg(last_5m):exclude_null(avg:system.disk.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) * 100 > 90"
   include_tags        = false
   notify_no_data      = false
   notify_audit        = false
@@ -34,8 +34,8 @@ resource "datadog_monitor" "disk_space" {
   require_full_window = true
 
   monitor_thresholds {
-    critical = 0.9
-    warning  = 0.8
+    critical = 90
+    warning  = 80
   }
 
   tags = ["terraformed:true", "*"]

--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -20,11 +20,11 @@ resource "datadog_monitor" "account_app_slow" {
 }
 
 resource "datadog_monitor" "disk_space" {
-  name    = "Available disk space is below {{ value }}% free for {{host.name}}"
+  name    = "Available disk space is above {{ value }}% used for {{host.name}}"
   type    = "query alert"
   message = "{{^is_warning}}@pagerduty{{/is_warning}}"
 
-  query = "avg(last_5m):exclude_null(avg:system.disk.free{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) / exclude_null(avg:system.disk.total{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) * 100 < 10"
+  query               = "avg(last_5m):exclude_null(avg:system.disk.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) > 0.9"
   include_tags        = false
   notify_no_data      = false
   notify_audit        = false
@@ -34,8 +34,8 @@ resource "datadog_monitor" "disk_space" {
   require_full_window = true
 
   monitor_thresholds {
-    critical = 10
-    warning  = 20
+    critical = 0.9
+    warning  = 0.8
   }
 
   tags = ["terraformed:true", "*"]

--- a/synthetics_jenkinsio.tf
+++ b/synthetics_jenkinsio.tf
@@ -12,7 +12,7 @@ resource "datadog_synthetics_test" "jenkinsio" {
   locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
-    
+
     retry {
       count    = 2
       interval = 300


### PR DESCRIPTION
Despite the `exclude_null()` correctly set, we saw warning on empty metrics which is weird.

While trying to understand these messages, we discovered the `system.disk.in_use` metric which is a fraction.

This PR utilizes this metric to simplify the disk monitor.

Tested manually and work as expected (only the `systempool` machines on `privatek8s` are in warn state)

![Capture d’écran 2023-05-10 à 17 04 09](https://github.com/jenkins-infra/datadog/assets/1522731/8f1dbdec-66aa-48b4-a22d-4529acbb8f46)



Note: this PR includes 2 additional changes:

- In a separate commit: bump the `.shared-tools`. It wasn't working locally for me without this update, not sure why (haven't looked)
- A terraformt fmt recursive changed a line on an unrelated file. Insce it's only a blank line, I've added the change