### PR TITLE
feat: add inodes monitoring

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -20,11 +20,33 @@ resource "datadog_monitor" "account_app_slow" {
 }
 
 resource "datadog_monitor" "disk_space" {
-  name    = "Available disk space is above {{ value }}% used for {{host.name}}"
+  name    = "Disk space is above {{ value }}% used for {{host.name}}"
   type    = "query alert"
   message = "{{^is_warning}}@pagerduty{{/is_warning}}"
 
   query               = "avg(last_5m):exclude_null(avg:system.disk.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) * 100 > 90"
+  include_tags        = false
+  notify_no_data      = false
+  notify_audit        = false
+  timeout_h           = 0
+  renotify_interval   = 0
+  new_group_delay     = 300
+  require_full_window = true
+
+  monitor_thresholds {
+    critical = 90
+    warning  = 80
+  }
+
+  tags = ["terraformed:true", "*"]
+}
+
+resource "datadog_monitor" "disk_inodes" {
+  name    = "Disk inodes is above {{ value }}% used for {{host.name}}"
+  type    = "query alert"
+  message = "{{^is_warning}}@pagerduty{{/is_warning}}"
+
+  query               = "avg(last_5m):exclude_null(avg:system.inodes.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) * 100 > 90"
   include_tags        = false
   notify_no_data      = false
   notify_audit        = false

--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -86,6 +86,30 @@ resource "datadog_monitor" "volume_space" {
   tags = ["terraformed:true", "*"]
 }
 
+
+resource "datadog_monitor" "volume_inodes" {
+  name    = "Available inodes is below {{ value }}% for the {{ persistentvolumeclaim.name }} PVC on {{ cluster_name.name }} cluster"
+  type    = "query alert"
+  message = "{{^is_warning}}@pagerduty{{/is_warning}}"
+
+  query = "avg(last_5m):exclude_null(avg:kubernetes.kubelet.volume.stats.inodes_free{*} by {cluster_name,persistentvolumeclaim}) / exclude_null(avg:kubernetes.kubelet.volume.stats.inodes{*} by {cluster_name,persistentvolumeclaim}) * 100 < 10"
+
+  include_tags        = false
+  notify_no_data      = false
+  notify_audit        = false
+  timeout_h           = 0
+  renotify_interval   = 0
+  new_group_delay     = 300
+  require_full_window = true
+
+  monitor_thresholds {
+    critical = 10
+    warning  = 20
+  }
+
+  tags = ["terraformed:true", "*"]
+}
+
 resource "datadog_monitor" "ssl_certificate_expiration" {
   name    = "SSL certificate expiring soon for {{url}}"
   type    = "metric alert"


### PR DESCRIPTION
We've recently been impacted by inodes full usage on infra.ci.jenkins.io, with this error in Jenkins logs:

> java.io.IOException: No space left on device

While space was left on the PV:
```
jenkins@jenkins-infra-0:/$ df -h
Filesystem      Size  Used Avail Use% Mounted on
overlay          97G   67G   30G  70% /
tmpfs            64M     0   64M   0% /dev
tmpfs           7.9G     0  7.9G   0% /sys/fs/cgroup
/dev/sda1        97G   67G   30G  70% /tmp
/dev/sdc         49G   32G   18G  66% /var/jenkins_home
shm              64M     0   64M   0% /dev/shm
tmpfs            13G  472K   13G   1% /run/secrets/additional
tmpfs            13G   12K   13G   1% /run/secrets/kubernetes.io/serviceaccount
tmpfs           7.9G     0  7.9G   0% /proc/acpi
tmpfs           7.9G     0  7.9G   0% /proc/scsi
tmpfs           7.9G     0  7.9G   0% /sys/firmware

```

No inode were free:
```
jenkins@jenkins-infra-0:~$ df -i /var/jenkins_home/
Filesystem      Inodes   IUsed IFree IUse% Mounted on
/dev/sdc       3276800 3276441   359  100% /var/jenkins_home
```

To avoid this kind of errors in the future, this PR adds inodes monitoring on disks and volumes.