### PR TITLE
fixup(disk inodes): correct query

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -46,7 +46,7 @@ resource "datadog_monitor" "disk_inodes" {
   type    = "query alert"
   message = "{{^is_warning}}@pagerduty{{/is_warning}}"
 
-  query               = "avg(last_5m):exclude_null(avg:system.inodes.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) * 100 > 90"
+  query               = "avg(last_5m):exclude_null(avg:system.fs.inodes.in_use{!device:tmpfs,!device:cgroup,!device:udev,!device:shm,!device:cgmfs,!label:UEFI,!label:uefi,!device:/dev/loop*} by {host,device}) * 100 > 90"
   include_tags        = false
   notify_no_data      = false
   notify_audit        = false


### PR DESCRIPTION
The monitor was in "no data" state since #185, this PR adds missing `.fs`

Fixup of #185 