### PR TITLE
chore: recreate as code the "LDAP process stopped" monitor

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -186,3 +186,25 @@ resource "datadog_monitor" "jenkins_buildqueue_size" {
 
   tags = ["terraformed:true", "*"]
 }
+
+resource "datadog_monitor" "ldap_process_stopped" {
+  name    = "LDAP process stopped"
+  type    = "process alert"
+  message = "Checked that the LDAP container is running correctly on {{ cluster_name.name }} by running \n```\nkubectl get pods -n ldap\n```\nAnd restart if necessary by running \n```\nkubectl delete pods -n ldap ldap-0\n``` @pagerduty"
+
+  query = "processes('ldap').over('command:slapd').rollup('count').last('5m') < 1"
+
+  notify_audit        = false
+  timeout_h           = 0
+  include_tags        = true
+  notify_no_data      = false
+  renotify_interval   = 0
+  new_group_delay     = 300
+  require_full_window = false
+
+  monitor_thresholds {
+    critical = 1
+  }
+
+  tags = ["terraformed:true", "*"]
+}

--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -199,7 +199,6 @@ resource "datadog_monitor" "ldap_process_stopped" {
   include_tags        = true
   notify_no_data      = false
   renotify_interval   = 0
-  new_group_delay     = 300
   require_full_window = false
 
   monitor_thresholds {


### PR DESCRIPTION
This PR recreates as code an existing monitor which will then be manually deleted.

<details>
<summary>Export as JSON of the existing monitor:</summary>

```json
{
	"id": 28992728,
	"name": "Ldap process stopped",
	"type": "process alert",
	"query": "processes('ldap').over('command:slapd').rollup('count').last('5m') < 1",
	"message": "Checked that the ldap container is running correctly by running \n```\nkubectl get pods -n ldap\n```\nAnd restart if necessary by running \n```\nkubectl delete pods -n ldap ldap-0\n``` @pagerduty",
	"tags": [],
	"options": {
		"thresholds": {
			"critical": 1
		},
		"renotify_interval": 0,
		"notify_audit": false,
		"timeout_h": 0,
		"include_tags": true,
		"no_data_timeframe": null,
		"require_full_window": false,
		"notify_no_data": false,
		"escalation_message": "",
		"silenced": {}
	},
	"priority": null,
	"restricted_roles": null
}
```

</details>

Ref: https://github.com/jenkins-infra/helpdesk/issues/3558