### PR TITLE
cleanup: ensure no more metrics from prodpublick8s are used for monitors

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -147,7 +147,7 @@ resource "datadog_monitor" "weird_response_time" {
 {{^is_warning}}@pagerduty{{/is_warning}}
 EOT
 
-  query = "avg(last_5m):max:network.http.response_time{production} by {url,cluster_name} > 5"
+  query = "avg(last_5m):exclude_null(max:network.http.response_time{!cluster_name:prodpublick8s,production} by {url,cluster_name}) > 5"
 
   notify_audit        = false
   timeout_h           = 0


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/3351, this PR exclude empty data AND data from `prodpublick8s` to avoid false alert now that the `datadog` namespace was removed from this cluster.

Tested manually and looks good!