### PR TITLE
fixup: correct code and trailing `/` for `jenkins.io` redirections monitors

### DIFF
--- a/synthetics_jenkinsio.tf
+++ b/synthetics_jenkinsio.tf
@@ -35,13 +35,13 @@ resource "datadog_synthetics_test" "jenkinsio_www_redirection" {
   assertion {
     type     = "statusCode"
     operator = "is"
-    target   = "302"
+    target   = "301"
   }
   assertion {
     type     = "header"
     property = "location"
     operator = "is"
-    target   = "https://www.jenkins.io"
+    target   = "https://www.jenkins.io/"
   }
   options_list {
     tick_every = 900
@@ -72,7 +72,7 @@ resource "datadog_synthetics_test" "jenkinsio_enforced_https" {
     type     = "header"
     property = "location"
     operator = "is"
-    target   = "https://www.jenkins.io"
+    target   = "https://www.jenkins.io/"
   }
   locations = ["aws:eu-central-1"]
   options_list {


### PR DESCRIPTION
Messed up the staging in my previous PR hence the 302 > 301, and add the missing trailing slash in target location header.

Fixup of #195 