### PR TITLE
feat: add `contributors.jenkins.io` synthetics monitoring

### DIFF
--- a/synthetics_contributorsjenkinsio.tf
+++ b/synthetics_contributorsjenkinsio.tf
@@ -1,0 +1,29 @@
+resource "datadog_synthetics_test" "contributors_jenkins_io" {
+  type = "api"
+  request_definition {
+    method = "GET"
+    url    = "https://contributors.jenkins.io"
+  }
+  assertion {
+    type     = "statusCode"
+    operator = "is"
+    target   = "200"
+  }
+  locations = ["aws:eu-central-1"]
+  options_list {
+    tick_every = 900
+
+    retry {
+      count    = 2
+      interval = 300
+    }
+  }
+  name    = "contributors.jenkins.io"
+  message = "Notify @pagerduty"
+  tags = [
+    "jenkins.io",
+    "production"
+  ]
+
+  status = "live"
+}


### PR DESCRIPTION
This PR adds monitoring for contributors.jenkins.io

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3809#issuecomment-1822357561