### PR TITLE
feat: add a monitor on Azure File Shares volume usage

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -110,6 +110,31 @@ resource "datadog_monitor" "volume_inodes" {
   tags = ["terraformed:true", "*"]
 }
 
+
+resource "datadog_monitor" "azurefileshare_space" {
+  name    = "Volume usage is above {{ value }}% for the {{ name }} Azure File Share"
+  type    = "query alert"
+  message = "{{^is_warning}}@pagerduty{{/is_warning}}"
+
+  query = "avg(last_5m):(avg:azure.storage_storageaccounts_fileservices.file_capacity{*} by {name} / avg:azure.storage_storageaccounts_fileservices.file_share_capacity_quota{*} by {name}) * 100 > 90"
+
+  include_tags        = false
+  notify_no_data      = false
+  notify_audit        = false
+  timeout_h           = 0
+  renotify_interval   = 0
+  new_group_delay     = 300
+  require_full_window = true
+
+  monitor_thresholds {
+    critical = 90
+    warning  = 80
+  }
+
+  tags = ["terraformed:true", "*"]
+}
+
+
 resource "datadog_monitor" "ssl_certificate_expiration" {
   name    = "SSL certificate expiring soon for {{url}}"
   type    = "metric alert"


### PR DESCRIPTION
This PR adds a monitor on all Azure File Shares to warn when their volume usage is above 80% of their quota, and to alert if above 90%.

Current usage in percent:
<img width="754" alt="image" src="https://github.com/jenkins-infra/datadog/assets/91831478/db35661e-5b29-4bce-8104-1416b2bcd3b6">

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3924