### PR TITLE
fix(incrementals): use `/readiness` endpoint returning a 200 status code

### DIFF
--- a/synthetics_incrementals.tf
+++ b/synthetics_incrementals.tf
@@ -2,15 +2,12 @@ resource "datadog_synthetics_test" "incrementalsjenkinsio" {
   type = "api"
   request_definition {
     method = "GET"
-    url    = "https://incrementals.jenkins.io/"
+    url    = "https://incrementals.jenkins.io/readiness"
   }
   assertion {
     type     = "statusCode"
     operator = "is"
-    # TODO: improve healthcheck on the incremental publisher app
-    ## Checking for an HTTP/404 covers some errors (all HTTP/5xx such as no pod running) but not all cases
-    ## Still better than no monitoring at all
-    target   = "404"
+    target   = "200"
   }
   locations = ["aws:eu-central-1"]
   options_list {

--- a/synthetics_incrementals.tf
+++ b/synthetics_incrementals.tf
@@ -2,6 +2,7 @@ resource "datadog_synthetics_test" "incrementalsjenkinsio" {
   type = "api"
   request_definition {
     method = "GET"
+    # https://github.com/jenkins-infra/incrementals-publisher/blob/a754f43d44be5f6b09e2ac3f9e5600e04175936b/index.js#L62
     url    = "https://incrementals.jenkins.io/readiness"
   }
   assertion {


### PR DESCRIPTION
This PR improves incrementals.jenkins.io synthetics monitor by watching the `/readiness` endpoint returning a 200 status code instead of `/` returning a 404 status code.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/3933