### PR TITLE
cleanup: remove monitors referencing removed clusters `cik8s`, `eks-public`, `doks` and `doks-public` and their hosted services

### DIFF
--- a/datadog-monitors.tf
+++ b/datadog-monitors.tf
@@ -172,7 +172,7 @@ resource "datadog_monitor" "weird_response_time" {
 {{^is_warning}}@pagerduty{{/is_warning}}
 EOT
 
-  query = "avg(last_5m):exclude_null(max:network.http.response_time{!cluster_name:prodpublick8s,!url:https://rating.jenkins.io,production} by {url,cluster_name}) > 5"
+  query = "avg(last_5m):exclude_null(max:network.http.response_time{cluster_name:publick8s,!url:https://rating.jenkins.io,production} by {url,cluster_name}) > 5"
 
   notify_audit        = false
   timeout_h           = 0

--- a/synthetics_incrementals.tf
+++ b/synthetics_incrementals.tf
@@ -3,7 +3,7 @@ resource "datadog_synthetics_test" "incrementalsjenkinsio" {
   request_definition {
     method = "GET"
     # https://github.com/jenkins-infra/incrementals-publisher/blob/a754f43d44be5f6b09e2ac3f9e5600e04175936b/index.js#L62
-    url    = "https://incrementals.jenkins.io/readiness"
+    url = "https://incrementals.jenkins.io/readiness"
   }
   assertion {
     type     = "statusCode"

--- a/variables.tf
+++ b/variables.tf
@@ -4,5 +4,5 @@ variable "datadog_jenkinsuser_password" {}
 variable "artifact_caching_proxy_providers" {
   description = "Available artifact-caching-proxy providers"
   type        = list(string)
-  default     = ["aws", "azure", "do"]
+  default     = ["azure"]
 }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/3954\#issuecomment-2119858778

This PR introduces 2 changes on the datadog monitor to avoid triggering alerts following the clusters removals:

- Remove `repo.aws` and `repo.do` ACP monitors
- Ensure that the HTTP response time are only checked through the `publick8s` (as doks-public is removed)