### PR TITLE
chore: set up pipeline to use the new staging backend

### DIFF
--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -3,15 +3,14 @@ parallel(
   'terraform': {
     terraform(
       stagingCredentials: [
-        // TODO: create an empty account for staging
-        string(variable: 'TF_VAR_datadog_api_key', credentialsId: 'datadog-api-key'),
-        string(variable: 'TF_VAR_datadog_app_key', credentialsId: 'datadog-app-key'),
+        string(variable: 'TF_VAR_datadog_api_key', credentialsId: 'staging-datadog-api-key'),
+        string(variable: 'TF_VAR_datadog_app_key', credentialsId: 'staging-datadog-app-key'),
         string(variable: 'TF_VAR_datadog_jenkinsuser_password', credentialsId: 'datadog-jenkinsuser-password'),
-        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-datadog-backend-config'),
+        file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-datadog-backend-config'),
       ],
       productionCredentials: [
-        string(variable: 'TF_VAR_datadog_api_key', credentialsId: 'datadog-api-key'),
-        string(variable: 'TF_VAR_datadog_app_key', credentialsId: 'datadog-app-key'),
+        string(variable: 'TF_VAR_datadog_api_key', credentialsId: 'production-datadog-api-key'),
+        string(variable: 'TF_VAR_datadog_app_key', credentialsId: 'production-datadog-app-key'),
         string(variable: 'TF_VAR_datadog_jenkinsuser_password', credentialsId: 'datadog-jenkinsuser-password'),
         file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-datadog-backend-config'),
       ],


### PR DESCRIPTION
Related to https://github.com/jenkins-infra/helpdesk/issues/4167, this PR introduces the following changes to the pipeline:

- Staging is now really using staging (distinct API key than production and read-only-scoped application key)
- Update production credential IDs

Note: had to run a `rm -rf ./.terraform && make -C .shared-tools/terraform/ validate` with both new `production` and `staging` backends to ensure the remote states are fully up to date.