### PR TITLE
feat(logs_pipeline) define and import the Cloudflare Logs pipelines

### DIFF
--- a/logs_pipeline.tf
+++ b/logs_pipeline.tf
@@ -25,6 +25,8 @@ resource "datadog_logs_pipeline_order" "custom_order" {
     datadog_logs_custom_pipeline.nginx_artifact_caching_proxy.id,
     datadog_logs_custom_pipeline.all_jenkins_infra_logs.id,
     datadog_logs_custom_pipeline.mirrorbits_logs.id,
+    datadog_logs_integration_pipeline.cloudflare.id,
+    datadog_logs_custom_pipeline.cloudflare_custom.id,
   ]
 }
 
@@ -58,12 +60,557 @@ resource "datadog_logs_integration_pipeline" "apache" {
 resource "datadog_logs_integration_pipeline" "redis" {
   is_enabled = true
 }
-import {
-  to = datadog_logs_integration_pipeline.ruby
-  id = "Nx_rG0R4Sx6o97dFkOHMsQ"
-}
 resource "datadog_logs_integration_pipeline" "ruby" {
   is_enabled = true
+}
+import {
+  to = datadog_logs_integration_pipeline.cloudflare
+  id = "NkxwLJB0RkmO2IxWaYYBTQ"
+}
+resource "datadog_logs_integration_pipeline" "cloudflare" {
+  # Default integration expectes 'source: cloudflare' which is not the case (see below)
+  is_enabled = false
+}
+import {
+  to = datadog_logs_custom_pipeline.cloudflare_custom
+  id = "xXniIpwkQTueOGSLB8KAiw"
+}
+resource "datadog_logs_custom_pipeline" "cloudflare_custom" {
+  filter {
+    query = "source:cloudflare-r2"
+  }
+  name       = "Cloudflare"
+  is_enabled = true
+
+  processor {
+    date_remapper {
+      is_enabled = true
+      name       = "Define `EdgeEndTimestamp` as the official date of the log"
+      sources = [
+        "EdgeEndTimestamp",
+      ]
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `ClientIP`, `SourceIP`, `SourceInternalIP`, `SrcIP`, `ActorIP`, `IP Address` to `network.client.ip`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "ClientIP",
+        "SourceIP",
+        "SourceInternalIP",
+        "SrcIP",
+        "ActorIP",
+        "IP Address",
+      ]
+      target        = "network.client.ip"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `ClientRequestMethod` to `http.method`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "ClientRequestMethod",
+      ]
+      target        = "http.method"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `EdgeResponseStatus` to `http.status_code`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "EdgeResponseStatus",
+      ]
+      target        = "http.status_code"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `ClientRequestReferer` to `http.referer`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "ClientRequestReferer",
+      ]
+      target        = "http.referer"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `EdgeResponseBytes` to `network.bytes_written`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "EdgeResponseBytes",
+      ]
+      target        = "network.bytes_written"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    url_parser {
+      is_enabled               = true
+      name                     = null
+      normalize_ending_slashes = false
+      sources = [
+        "ClientRequestURI",
+      ]
+      target = "http.url_details"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `HTTPHost`, `ClientRequestHost` to `http.url_details.host`"
+      override_on_conflict = true
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "HTTPHost",
+        "ClientRequestHost",
+      ]
+      target        = "http.url_details.host"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    user_agent_parser {
+      is_enabled = true
+      is_encoded = false
+      name       = null
+      sources = [
+        "ClientRequestUserAgent",
+      ]
+      target = "http.useragent_details"
+    }
+  }
+  processor {
+    category_processor {
+      is_enabled = true
+      name       = "Categorise status code"
+      target     = "http.status_category"
+
+      category {
+        name = "OK"
+
+        filter {
+          query = "@http.status_code:[200 TO 299]"
+        }
+      }
+      category {
+        name = "notice"
+
+        filter {
+          query = "@http.status_code:[300 TO 399]"
+        }
+      }
+      category {
+        name = "warning"
+
+        filter {
+          query = "@http.status_code:[400 TO 499]"
+        }
+      }
+      category {
+        name = "error"
+
+        filter {
+          query = "@http.status_code:[500 TO 599]"
+        }
+      }
+    }
+  }
+  processor {
+    status_remapper {
+      is_enabled = true
+      name       = "Define `http.status_category` as the official status of the log"
+      sources = [
+        "http.status_category",
+      ]
+    }
+  }
+  processor {
+    arithmetic_processor {
+      expression         = "EdgeEndTimestamp - EdgeStartTimestamp"
+      is_enabled         = true
+      is_replace_missing = false
+      name               = "Calculate request response time"
+      target             = "duration"
+    }
+  }
+  processor {
+    geo_ip_parser {
+      is_enabled = true
+      name       = "Fetching GeoIp data for client ip"
+      sources = [
+        "network.client.ip",
+      ]
+      target = "network.client.geoip"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `ClientASN` to `network.client.asn`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "ClientASN",
+      ]
+      target        = "network.client.asn"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `DeviceName` to `host`"
+      override_on_conflict = false
+      preserve_source      = true
+      source_type          = "attribute"
+      sources = [
+        "DeviceName",
+      ]
+      target        = "host"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `Email`, `ActorEmail` to `usr.email`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "Email",
+        "ActorEmail",
+      ]
+      target        = "usr.email"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `UserID`, `UserUID`, `ActorID` to `usr.id`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "UserID",
+        "UserUID",
+        "ActorID",
+      ]
+      target        = "usr.id"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `OriginIP`, `DstIP`, `DestinationIP` to `network.destination.ip`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "OriginIP",
+        "DstIP",
+        "DestinationIP",
+      ]
+      target        = "network.destination.ip"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `OriginPort`, `DstPort`, `DestinationPort` to `network.destination.port`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "OriginPort",
+        "DstPort",
+        "DestinationPort",
+      ]
+      target        = "network.destination.port"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `SourcePort`, `SrcPort` to `network.client.port`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "SourcePort",
+        "SrcPort",
+      ]
+      target        = "network.client.port"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `QueryName` to `dns.question.name`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "QueryName",
+      ]
+      target        = "dns.question.name"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `QuerySize` to `dns.question.size`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "QuerySize",
+      ]
+      target        = "dns.question.size"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `QueryTypeName` to `dns.question.type`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "QueryTypeName",
+      ]
+      target        = "dns.question.type"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `ResolvedIPs` to `dns.answer.name`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "ResolvedIPs",
+      ]
+      target        = "dns.answer.name"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `RCode` to `dns.flag.rcode`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "RCode",
+      ]
+      target        = "dns.flag.rcode"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `HTTPMethod` to `http.method`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "HTTPMethod",
+      ]
+      target        = "http.method"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `HTTPStatusCode` to `http.status_code`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "HTTPStatusCode",
+      ]
+      target        = "http.status_code"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `HTTPVersion` to `http.version`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "HTTPVersion",
+      ]
+      target        = "http.version"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `Referer` to `http.referer`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "Referer",
+      ]
+      target        = "http.referer"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `RayID` to `http.request_id`"
+      override_on_conflict = false
+      preserve_source      = true
+      source_type          = "attribute"
+      sources = [
+        "RayID",
+      ]
+      target        = "http.request_id"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `URL` to `http.url`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "URL",
+      ]
+      target        = "http.url"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `UserAgent` to `http.useragent`"
+      override_on_conflict = false
+      preserve_source      = false
+      source_type          = "attribute"
+      sources = [
+        "UserAgent",
+      ]
+      target        = "http.useragent"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `AssetMetadata.Email` to `usr.email`"
+      override_on_conflict = false
+      preserve_source      = true
+      source_type          = "attribute"
+      sources = [
+        "AssetMetadata.Email",
+      ]
+      target        = "usr.email"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `AssetMetadata.Name` to `usr.name`"
+      override_on_conflict = false
+      preserve_source      = true
+      source_type          = "attribute"
+      sources = [
+        "AssetMetadata.Name",
+      ]
+      target        = "usr.name"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
+  processor {
+    attribute_remapper {
+      is_enabled           = true
+      name                 = "Map `AssetMetadata.Id` to `usr.id`"
+      override_on_conflict = false
+      preserve_source      = true
+      source_type          = "attribute"
+      sources = [
+        "AssetMetadata.Id",
+      ]
+      target        = "usr.id"
+      target_format = null
+      target_type   = "attribute"
+    }
+  }
 }
 
 ## TODO: describe the intent of this pipeline (remap status? Check request caching status? Other?)


### PR DESCRIPTION
Following https://github.com/jenkins-infra/helpdesk/issues/4372 (in the context of https://github.com/jenkins-infra/helpdesk/issues/2649), we had to update the Logs Pipeline to properly parse the access logs pushed by Cloudflare to datadog.

The default integration was enabled automatically after we started to push logs to datadog, but it targets the `source` set to `cloudflare` while we set it up to be `cloudlfare-r2`.

This PR is a first step to import the configuration we did manually in Datadog UI:

- Disabled the default integration (for now?)
- Duplicated it so we could set the `source` filter to the value we need.

Notes:
- This PR expects 2 imports and no changes as tested locally
- We need a subsequent PR with `updatecli` to retrieve the source value from the Terraform Cloudflare project repository.