### PR TITLE
fix(logs_pipeline) parse all kind of mirrorbits message with the proper attributes and log_level to stop pushing false-positive `ERROR` messages

### DIFF
--- a/imports.tf
+++ b/imports.tf
@@ -1,56 +1,12 @@
 import {
-  to = datadog_logs_pipeline_order.custom_order
-  id = "custom_order"
+  to = datadog_logs_custom_pipeline.mirrorbits_scan_mirrors_logs
+  id = "5NZhKxKZSsema717VHp2mw"
 }
 import {
-  to = datadog_logs_integration_pipeline.glog
-  id = "GBMY7pSvQNS73VUKftObug"
+  to = datadog_logs_custom_pipeline.mirrorbits_scan_repo_logs
+  id = "2tJ_0biaSWaN6I43gDJehg"
 }
-import {
-  to = datadog_logs_integration_pipeline.core_dns
-  id = "EywBVhkjT92neHN6vjEKTA"
-}
-import {
-  to = datadog_logs_integration_pipeline.datadog_agent
-  id = "UdqO5Hj3SDC8ljPYXXqaBw"
-}
-import {
-  to = datadog_logs_integration_pipeline.nginx
-  id = "4ydx_fVjQnK9YFS5BnAUFA"
-}
-import {
-  to = datadog_logs_integration_pipeline.httpd
-  id = "ipaD0UrmRryuF-2c2xDl0Q"
-}
-import {
-  to = datadog_logs_integration_pipeline.mysql
-  id = "-l0ckMq3SF6hZ5AfRj695Q"
-}
-import {
-  to = datadog_logs_integration_pipeline.kube_cluster_autoscaler
-  id = "w3a92nepTJOJallFRaStDA"
-}
-import {
-  to = datadog_logs_integration_pipeline.docker
-  id = "Uoko5fY2Qwia6aE0gThMKQ"
-}
-import {
-  to = datadog_logs_integration_pipeline.apache
-  id = "dcx-DNdiRUSrATNfl68ntw"
-}
-import {
-  to = datadog_logs_integration_pipeline.redis
-  id = "r3SGsLKeQHqjEeRDu7e-2w"
-}
-import {
-  to = datadog_logs_custom_pipeline.nginx_artifact_caching_proxy
-  id = "kbY4d4OBRiWirblCoZM9dg"
-}
-import {
-  to = datadog_logs_custom_pipeline.all_jenkins_infra_logs
-  id = "dsthWMosTI-tDc6DYW07rg"
-}
-import {
-  to = datadog_logs_custom_pipeline.mirrorbits_logs
-  id = "3AWzA8nfROuJaYf3rrGGPg"
+moved {
+  from = datadog_logs_custom_pipeline.mirrorbits_logs
+  to   = datadog_logs_custom_pipeline.mirrorbits_general_logs
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/2649