### PR TITLE
feat(logs_pipeline) import the new 'openvpn' log pipeline

### DIFF
--- a/logs_pipeline.tf
+++ b/logs_pipeline.tf
@@ -30,6 +30,7 @@ resource "datadog_logs_pipeline_order" "custom_order" {
     datadog_logs_integration_pipeline.cloudflare.id,
     datadog_logs_integration_pipeline.keycloak.id,
     datadog_logs_integration_pipeline.falco.id,
+    datadog_logs_integration_pipeline.openvpn.id,
   ]
 }
 
@@ -73,6 +74,13 @@ resource "datadog_logs_integration_pipeline" "keycloak" {
   is_enabled = true
 }
 resource "datadog_logs_integration_pipeline" "falco" {
+  is_enabled = true
+}
+import {
+  to = datadog_logs_integration_pipeline.openvpn
+  id = "Hotm_CQBQZKLdVjCwnq8fw"
+}
+resource "datadog_logs_integration_pipeline" "openvpn" {
   is_enabled = true
 }
 

--- a/synthetics_plugin-health-scoring.tf
+++ b/synthetics_plugin-health-scoring.tf
@@ -10,10 +10,10 @@ resource "datadog_synthetics_test" "plugin_health_scoring" {
     target   = "200"
   }
   assertion {
-    type = "body"
+    type     = "body"
     operator = "validatesJSONPath"
     targetjsonpath {
-      jsonpath         = "$.status"      
+      jsonpath         = "$.status"
       operator         = "is"
       elementsoperator = "firstElementMatches"
       targetvalue      = "UP"


### PR DESCRIPTION
A new pipeline log aggregator has been added by Datadog in their UI, making the Terraform job shifting.

This PR imports this new pipeline, `openvpn`