### PR TITLE
fix(synthetics/updatecenter) attempt to decrease false positive alerts

### DIFF
--- a/synthetics_updatecenter.tf
+++ b/synthetics_updatecenter.tf
@@ -46,7 +46,7 @@ resource "datadog_synthetics_test" "updates_center" {
   locations = [
     "aws:eu-central-1",
     "aws:us-east-2",
-    "azure:USEast2",
+    "azure:eastus",
   ]
   options_list {
     tick_every       = 60
@@ -87,7 +87,11 @@ resource "datadog_synthetics_test" "updates_center_http_to_https" {
     operator = "is"
     target   = trimsuffix(format("https://%s", each.key), "/") # Redirection to the same URL but without trailing slashes
   }
-  locations = ["aws:eu-central-1"]
+  locations = [
+    "aws:eu-central-1",
+    "aws:us-east-2",
+    "azure:eastus",
+  ]
   options_list {
     tick_every = 900
     retry {

--- a/synthetics_updatecenter.tf
+++ b/synthetics_updatecenter.tf
@@ -43,10 +43,18 @@ resource "datadog_synthetics_test" "updates_center" {
     operator = "is"
     target   = "200"
   }
-  locations = ["aws:eu-central-1"]
+  locations = [
+    "aws:eu-central-1",
+    "aws:us-east-2",
+    "azure:USEast2",
+  ]
   options_list {
     tick_every       = 60
     follow_redirects = true
+    retry {
+      count    = 3
+      interval = 900
+    }
   }
   name    = each.key
   message = "Notify @pagerduty"
@@ -82,6 +90,10 @@ resource "datadog_synthetics_test" "updates_center_http_to_https" {
   locations = ["aws:eu-central-1"]
   options_list {
     tick_every = 900
+    retry {
+      count    = 3
+      interval = 900
+    }
   }
   name = each.key
   message = "Notify @pagerduty"


### PR DESCRIPTION
The datadog synthetics fails quite often on the update center with the error `NGHTTP2_REFUSED_STREAM`:

<img width="1352" height="878" alt="Capture d’écran 2025-08-06 à 17 23 44" src="https://github.com/user-attachments/assets/c9047d4d-fba6-4802-8af5-e018ba3bae2a" />

This PR introduces 2 changes in these synthetics to ensure we don't get that much positives while keeping the monitoring:

- Many locations (2 different clouds, 2 continents and 3 geographical zones) to ponder errors (in case it comes from datadog infrastructure)
- Retry 3 times the requests before triggering the monitor
