### PR TITLE
feat(monitoring): add datadog synthetics for jenkins build status monitoring

### DIFF
--- a/synthetics_build-reports.tf
+++ b/synthetics_build-reports.tf
@@ -23,7 +23,7 @@ resource "datadog_synthetics_test" "docker_404" {
     }
   }
   name    = "docker-404 build status"
-  message = "Notify @pagerduty"
+  # message = "Notify @pagerduty"
   tags    = ["production", "jenkins-infra", "docker-404"]
   status = "live"
 }


### PR DESCRIPTION
As per https://github.com/jenkins-infra/helpdesk/issues/2843#issuecomment-3154109928 

This PR

- Add synthetic tests for critical jenkins jobs
- Monitor docker-404
- Alert on build failures and missing reports via @pagerduty