### PR TITLE
fix(synthetics_build-reports): Use `jsonpath` operator for build success assertion

### DIFF
--- a/synthetics_build-reports.tf
+++ b/synthetics_build-reports.tf
@@ -10,9 +10,13 @@ resource "datadog_synthetics_test" "docker_404" {
     target   = "200"
   }
   assertion {
-    type     = "body"
-    operator = "contains"
-    target   = "\"build_status\":\"SUCCESS\""
+  type     = "body"
+  operator = "validatesJSONPath"
+  targetjsonpath {
+    jsonpath    = "$.build_status"
+    operator    = "is"
+    targetvalue = "SUCCESS"
+    }
   }
   locations = ["aws:eu-central-1"]
   options_list {


### PR DESCRIPTION
As per https://github.com/jenkins-infra/datadog/pull/313#issuecomment-3183935712:

Related to https://github.com/jenkins-infra/helpdesk/issues/2843

we now use `jsonpath` to test build success