### PR TITLE
feat: add API and Application keys for `infracijenkinsio-agents-1`

### DIFF
--- a/keys.tf
+++ b/keys.tf
@@ -1,0 +1,9 @@
+resource "datadog_api_key" "infracijenkinsio_agents_1" {
+  name = "infracijenkinsio-agents-1"
+}
+
+# See the permissions available for scoped keys at https://docs.datadoghq.com/account_management/rbac/permissions/#permissions-list
+resource "datadog_application_key" "infracijenkinsio_agents_1" {
+  name = "infracijenkinsio-agents-1"
+  # scopes unset - inherits all user permissions
+}


### PR DESCRIPTION
This change creates an API and an Application keys for the new AKS cluster `infracijenkinsio-agents-1` similar to the `infracijenkinsio-agents-2` one, but as code instead of manually.

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5043