### PR TITLE
chore(infracijenkinsio-agents-1): remove unused Application key

### DIFF
--- a/keys.tf
+++ b/keys.tf
@@ -1,9 +1,5 @@
+## TODO: import existing API keys while we can (won't be possible in the future)
+
 resource "datadog_api_key" "infracijenkinsio_agents_1" {
   name = "infracijenkinsio-agents-1"
-}
-
-# See the permissions available for scoped keys at https://docs.datadoghq.com/account_management/rbac/permissions/#permissions-list
-resource "datadog_application_key" "infracijenkinsio_agents_1" {
-  name = "infracijenkinsio-agents-1"
-  # scopes unset - inherits all user permissions
 }


### PR DESCRIPTION
Refs:
- https://docs.datadoghq.com/account_management/api-app-keys/#application-keys
- https://registry.terraform.io/providers/DataDog/datadog/latest/docs/resources/api_key
  - > Provides a Datadog API Key resource. This can be used to create and manage Datadog API Keys. **Import functionality for this resource is deprecated and will be removed in a future release with prior notice**.
- https://github.com/jenkins-infra/helpdesk/issues/5043
