### PR TITLE
feat(build-report-jobs): add all build report jobs to reachability monitor

### DIFF
--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -10,42 +10,6 @@ build_report_jobs:
     controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
-  docker-confluence-data:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-confluence-data/main
-    threshold_minutes: 1440
-  docker-geoipupdate:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-geoipupdate/main
-    threshold_minutes: 1440
-  docker-jenkins-infraci:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-jenkins-infraci/main
-    threshold_minutes: 1440
-  docker-jenkins-lts:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-jenkins-lts/main
-    threshold_minutes: 1440
-  docker-jenkins-weeklyci:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-jenkins-weeklyci/main
-    threshold_minutes: 1440
-  docker-openvpn:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-openvpn/main
-    threshold_minutes: 1440
-  docker-packaging:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-packaging/main
-    threshold_minutes: 1440
-  plugin-health-scoring:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/plugin-health-scoring/main
-    threshold_minutes: 1440
-  rating:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/rating/master
-    threshold_minutes: 1440
   kubernetes-management:
     controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
@@ -81,4 +45,8 @@ build_report_jobs:
   release-infra-agents-health:
     controller: release.ci.jenkins.io
     job: infra-agents-health
+    threshold_minutes: 1440
+  cert-acceptance-tests:
+    controller: infra.ci.jenkins.io
+    job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440

--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -46,7 +46,3 @@ build_report_jobs:
     controller: release.ci.jenkins.io
     job: infra-agents-health
     threshold_minutes: 1440
-  cert-acceptance-tests:
-    controller: infra.ci.jenkins.io
-    job: acceptance-tests/acceptance-tests/check-agent-availability
-    threshold_minutes: 1440

--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -7,6 +7,78 @@ build_report_jobs:
     job: docker-jobs/docker-404/main
     threshold_minutes: 1440
   acceptance-tests:
-    controller: ci.jenkins.io
-    job: acceptance-tests/check-agent-availability
+    controller: infra.ci.jenkins.io
+    job: acceptance-tests/acceptance-tests/check-agent-availability
+    threshold_minutes: 1440
+  docker-confluence-data:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-confluence-data/main
+    threshold_minutes: 1440
+  docker-geoipupdate:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-geoipupdate/main
+    threshold_minutes: 1440
+  docker-jenkins-infraci:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-jenkins-infraci/main
+    threshold_minutes: 1440
+  docker-jenkins-lts:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-jenkins-lts/main
+    threshold_minutes: 1440
+  docker-jenkins-weeklyci:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-jenkins-weeklyci/main
+    threshold_minutes: 1440
+  docker-openvpn:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-openvpn/main
+    threshold_minutes: 1440
+  docker-packaging:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-packaging/main
+    threshold_minutes: 1440
+  plugin-health-scoring:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/plugin-health-scoring/main
+    threshold_minutes: 1440
+  rating:
+    controller: infra.ci.jenkins.io
+    job: docker-jobs/rating/master
+    threshold_minutes: 1440
+  kubernetes-management:
+    controller: infra.ci.jenkins.io
+    job: kubernetes-jobs/kubernetes-management/main
+    threshold_minutes: 1440
+  terraform-azure:
+    controller: infra.ci.jenkins.io
+    job: terraform-jobs/azure/main
+    threshold_minutes: 1440
+  terraform-azure-net:
+    controller: infra.ci.jenkins.io
+    job: terraform-jobs/azure-net/main
+    threshold_minutes: 1440
+  terraform-datadog:
+    controller: infra.ci.jenkins.io
+    job: terraform-jobs/datadog/main
+    threshold_minutes: 1440
+  terraform-digitalocean:
+    controller: infra.ci.jenkins.io
+    job: terraform-jobs/digitalocean/main
+    threshold_minutes: 1440
+  terraform-aws-sponsorship:
+    controller: infra.ci.jenkins.io
+    job: terraform-jobs/terraform-aws-sponsorship/main
+    threshold_minutes: 1440
+  update-center:
+    controller: trusted.ci.jenkins.io
+    job: update_center
+    threshold_minutes: 10
+  trusted-acceptance-tests:
+    controller: trusted.ci.jenkins.io
+    job: acceptance-tests-check-agent-availability
+    threshold_minutes: 1440
+  release-infra-agents-health:
+    controller: release.ci.jenkins.io
+    job: infra-agents-health
     threshold_minutes: 1440

--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -6,3 +6,7 @@ build_report_jobs:
     controller: infra.ci.jenkins.io
     job: docker-jobs/docker-404/main
     threshold_minutes: 1440
+  acceptance-tests:
+    controller: ci.jenkins.io
+    job: acceptance-tests/check-agent-availability
+    threshold_minutes: 1440

--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -6,9 +6,17 @@ build_report_jobs:
     controller: infra.ci.jenkins.io
     job: docker-jobs/docker-404/main
     threshold_minutes: 1440
-  acceptance-tests:
+  acceptance-tests-infra-ci:
     controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
+    threshold_minutes: 1440
+  acceptance-tests-release-ci:
+    controller: release.ci.jenkins.io
+    job: infra-agents-health
+    threshold_minutes: 1440
+  acceptance-tests-trusted-ci:
+    controller: trusted.ci.jenkins.io
+    job: acceptance-tests-check-agent-availability
     threshold_minutes: 1440
   kubernetes-management:
     controller: infra.ci.jenkins.io
@@ -38,11 +46,3 @@ build_report_jobs:
     controller: trusted.ci.jenkins.io
     job: update_center
     threshold_minutes: 10
-  trusted-acceptance-tests:
-    controller: trusted.ci.jenkins.io
-    job: acceptance-tests-check-agent-availability
-    threshold_minutes: 1440
-  release-infra-agents-health:
-    controller: release.ci.jenkins.io
-    job: infra-agents-health
-    threshold_minutes: 1440


### PR DESCRIPTION
Ref: 
- https://github.com/jenkins-infra/helpdesk/issues/2843

Adds all currently publishing jobs  except docker-jobs on [builds.reports.jenkins.io](https://builds.reports.jenkins.io/build_status_reports/) to the staleness monitor via `build-report-jobs.yaml`.

### Not included

- All docker jobs
- cert.ci jobs