### PR TITLE
feat(monitor-build-reports): add per-job opt-in for build report alerting

### DIFF
--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -22,6 +22,7 @@ build_report_jobs:
     controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
     threshold_minutes: 1440
+    enable_alert: true   # opt-in for publishing alerts
   terraform-azure:
     controller: infra.ci.jenkins.io
     job: terraform-jobs/azure/main
@@ -46,3 +47,4 @@ build_report_jobs:
     controller: trusted.ci.jenkins.io
     job: update_center
     threshold_minutes: 10
+    enable_alert: true   # opt-in for publishing alerts

--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -43,7 +43,7 @@ resource "datadog_monitor" "build_report_stale" {
   no_data_timeframe   = 120
   renotify_interval   = 60
   require_full_window = false
-  draft_status        = "draft"
+  draft_status        = lookup(each.value, "enable_alert", false) ? "" : "draft"
 
   monitor_thresholds {
     critical = 1
@@ -84,7 +84,7 @@ resource "datadog_monitor" "build_report_unreachable" {
   no_data_timeframe   = 120
   renotify_interval   = 60
   require_full_window = false
-  draft_status        = "draft"
+  draft_status        = lookup(each.value, "enable_alert", false) ? "" : "draft"
 
   monitor_thresholds {
     critical = 1

--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -43,7 +43,7 @@ resource "datadog_monitor" "build_report_stale" {
   no_data_timeframe   = 120
   renotify_interval   = 60
   require_full_window = false
-  draft_status        = lookup(each.value, "enable_alert", false) ? "" : "draft"
+  draft_status        = lookup(each.value, "enable_alert", false) ? "published" : "draft"
 
   monitor_thresholds {
     critical = 1
@@ -84,7 +84,7 @@ resource "datadog_monitor" "build_report_unreachable" {
   no_data_timeframe   = 120
   renotify_interval   = 60
   require_full_window = false
-  draft_status        = lookup(each.value, "enable_alert", false) ? "" : "draft"
+  draft_status        = lookup(each.value, "enable_alert", false) ? "published" : "draft"
 
   monitor_thresholds {
     critical = 1


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

Introduces `enable_alert` key in build-report-jobs.yaml to control
whether individual monitors are published or kept in draft.

Jobs without `enable_alert` remain in draft (no notifications).
Jobs with `enable_alert: true` are published and will fire alerts.

Enabled for: update_center (trusted.ci), kubernetes-management (infra.ci)

