### PR TITLE
chore(logs_pipeline.tf): remove python pipeline import block after successful apply

### DIFF
--- a/logs_pipeline.tf
+++ b/logs_pipeline.tf
@@ -96,11 +96,6 @@ resource "datadog_logs_integration_pipeline" "python" {
   is_enabled = true
 }
 
-import {
-  to = datadog_logs_integration_pipeline.python
-  id = "xRfcYyn6ScyP0YYroj7g1g"
-}
-
 ## TODO: describe the intent of this pipeline (remap status? Check request caching status? Other?)
 resource "datadog_logs_custom_pipeline" "nginx_artifact_caching_proxy" {
   filter {


### PR DESCRIPTION


Remove the `import` block for `datadog_logs_integration_pipeline.python` added in #348,
now that it has been successfully applied and the resource is in Terraform state.

Principal branch build was success: https://infra.ci.jenkins.io/job/terraform-jobs/job/datadog/job/main/78/

```
Terraform will perform the following actions:

  # datadog_logs_integration_pipeline.python will be imported
    resource "datadog_logs_integration_pipeline" "python" {
        id         = "xRfcYyn6ScyP0YYroj7g1g"
        is_enabled = true
    }

Plan: 1 to import, 0 to add, 0 to change, 0 to destroy.

```