### PR TITLE
feat(monitor-build-reports): enable alerting by default

### DIFF
--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -43,7 +43,7 @@ resource "datadog_monitor" "build_report_stale" {
   no_data_timeframe   = 120
   renotify_interval   = 60
   require_full_window = false
-  draft_status        = lookup(each.value, "enable_alert", false) ? "published" : "draft"
+  draft_status        = lookup(each.value, "enable_alert", true) ? "published" : "draft"
 
   monitor_thresholds {
     critical = 1


### PR DESCRIPTION
This change inverses the logic so build monitoring alerts are enabled by default, to avoid adding `enable_alerting: true` to every build monitors in https://github.com/jenkins-infra/datadog/blob/5b99daf91bc3c37f72f210fbbefb47a3f3d4090c/build-report-jobs.yaml (and using `enable_alerting: false` for when we want to introduce new monitors in draft)

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5136