### PR TITLE
feat: remove `docker-404` job from build-report-jobs.yaml

### DIFF
--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -7,10 +7,6 @@ build_report_jobs:
     controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
-  docker-404:
-    controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-404/main
-    threshold_minutes: 1440
   kubernetes-management:
     controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main


### PR DESCRIPTION
Removed docker-404 job from build report monitoring.

Ref:
- https://github.com/jenkins-infra/datadog/pull/353#issuecomment-4553707361