### PR TITLE
fix(build-report/release.ci): proper `infra-agents-health` job path

### DIFF
--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -12,11 +12,6 @@ build_report_jobs:
     job: kubernetes-jobs/kubernetes-management/main
     threshold_minutes: 1440
     enable_alert: true   # opt-in for publishing alerts
-  ## release.ci.jenkins.io jobs
-  acceptance-tests-release-ci:
-    controller: release.ci.jenkins.io
-    job: infra-agents-health
-    threshold_minutes: 1440
   terraform-azure:
     controller: infra.ci.jenkins.io
     job: terraform-jobs/azure/main
@@ -36,6 +31,11 @@ build_report_jobs:
   terraform-aws-sponsorship:
     controller: infra.ci.jenkins.io
     job: terraform-jobs/terraform-aws-sponsorship/main
+    threshold_minutes: 1440
+  ## release.ci.jenkins.io jobs
+  acceptance-tests-release-ci:
+    controller: release.ci.jenkins.io
+    job: infra-agents-health/master
     threshold_minutes: 1440
   ## trusted.ci.jenkins.io jobs
   acceptance-tests-trusted-ci:

--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -36,7 +36,7 @@ build_report_jobs:
   acceptance-tests-release-ci:
     controller: release.ci.jenkins.io
     job: infra-agents-health/master
-    threshold_minutes: 1440
+    threshold_minutes: 1440  # 1 day (1 build)
   ## trusted.ci.jenkins.io jobs
   acceptance-tests-trusted-ci:
     controller: trusted.ci.jenkins.io


### PR DESCRIPTION
This change updates the job path of this build report monitoring as its job type changed from "Pipeline" to "Multibranch pipeline", thus the build report path used to be https://builds.reports.jenkins.io/build_status_reports/release.ci.jenkins.io/infra-agents-health/status.json and is now https://builds.reports.jenkins.io/build_status_reports/release.ci.jenkins.io/infra-agents-health/master/status.json

Fixup of:
- https://github.com/jenkins-infra/kubernetes-management/pull/7757

Ref:
- https://github.com/jenkins-infra/helpdesk/issues/5091#issuecomment-4381409952