### PR TITLE
feat(build-report-jobs.yaml) add docs.jenkins.io to build report monitoring

### DIFF
--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -67,3 +67,8 @@ build_report_jobs:
     job: update_center
     threshold_minutes: 20  # (2 builds)
     enable_alert: true   # opt-in for publishing alerts
+  docs-jenkins-io:
+    controller: infra.ci.jenkins.io
+    job: website-production-jobs/docs.jenkins.io/main
+    threshold_minutes: 10
+    enable_alert: true


### PR DESCRIPTION
Part of 
- jenkins-infra/helpdesk#5159 

adding build report monitoring to docs.jenkins.io production deployment jobs.
