### PR TITLE
chore(backends) use clear-text backend config with only the `ARM_CLIENT_SECRET` as credential

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,8 +28,6 @@ override.tf.json
 # Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
 # example: *tfplan*
 
-# Custom backend setup
-backend-config
 kubeconfig*
 terraform-plan-for-humans.txt
 terraform-plan-output.txt

--- a/Jenkinsfile_k8s
+++ b/Jenkinsfile_k8s
@@ -4,12 +4,12 @@ terraform(
     string(variable: 'TF_VAR_datadog_api_key', credentialsId: 'staging-datadog-api-key'),
     string(variable: 'TF_VAR_datadog_app_key', credentialsId: 'staging-datadog-app-key'),
     string(variable: 'TF_VAR_datadog_jenkinsuser_password', credentialsId: 'datadog-jenkinsuser-password'),
-    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'staging-terraform-datadog-backend-config'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'staging-terraform-datadog-backend-config-arm-secret'),
   ],
   productionCredentials: [
     string(variable: 'TF_VAR_datadog_api_key', credentialsId: 'production-datadog-api-key'),
     string(variable: 'TF_VAR_datadog_app_key', credentialsId: 'production-datadog-app-key'),
     string(variable: 'TF_VAR_datadog_jenkinsuser_password', credentialsId: 'datadog-jenkinsuser-password'),
-    file(variable: 'BACKEND_CONFIG_FILE', credentialsId: 'production-terraform-datadog-backend-config'),
+    string(variable: 'TF_BACKEND_ARM_CLIENT_SECRET', credentialsId:'production-terraform-datadog-backend-config-arm-secret'),
   ],
 )

--- a/README.adoc
+++ b/README.adoc
@@ -9,16 +9,36 @@ This repository hosts the infrastructure-as-code definition for all the link:htt
 
 * An access to the Jenkins Datadog account for the Jenkins Infrastructure at https://jenkins.datadoghq.com.
 * The requirements (of the shared tools) listed at link:https://github.com/jenkins-infra/shared-tools/tree/main/terraform#requirements[shared-tools/terraform#requirements]
-* The link:https://www.terraform.io/language/settings/backends/azurerm[Terraform AzureRM Backend Configuration] on a local file named `backend-config`:
-** The content can be retrieved from the credentials of infra.ci.jenkins.io.
-** This file (`backend-config`) is git-ignored
-
-* The git command line to allow cloning the repository and its submodule link:https://github.com/jenkins-infra/shared-tools[shared-tools]
-** This repository has submodules. Once you cloned the repository, execute the following command to obtain the shared tools:
+* The link:https://github.com/jenkins-infra/shared-tools[shared-tools] common repository as a git submodule should be initialized and up-to-date:
+** On a freshly cloned Terraform repository, execute the following command to obtain the shared tools:
 
 [source,bash]
 ----
 git submodule update --init --recursive
+----
+
+** Otherwise you should update to to the latest `main` branch:
+
+[source,bash]
+----
+cd ./.shared-tools
+git pull origin main
+cd ../
+----
+
+* The Azure Credential Secret value to allow the Terraform AzureRM Backend to access remote Azure storage:
+** Must be specified in the environment variable `TF_BACKEND_ARM_CLIENT_SECRET`
+** The secret value should never be written in clear (not in a text file, not in the terminal). For instance on macOS, store it in your Keychain access and set the variable with `export TF_BACKEND_ARM_CLIENT_SECRET="$(security find-generic-password -a jenkins-tf-datadog-backend-arm-secret -w)"`
+
+* Routing to database (private endpoints and private DNSes):
+** VPN access is required with routing to the database subnets set up to your user
+** As there are no public DNS, set up your local `/etc/hosts` (check the `providers.tf` for details)
+
+* If you intend to work with the production, the environment variable `TF_VAR_environment` must be set:
+
+[source,bash]
+----
+export TF_VAR_environment=production
 ----
 
 == Monitors

--- a/backend-configs/production
+++ b/backend-configs/production
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-datadog-production-cWZ5is"
+storage_account_name = "datadogproductioncwz5is"
+container_name       = "datadogproductioncwz5is"
+client_id            = "fe757a96-ab39-48f6-97a3-3c28ace22de4"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend-configs/staging
+++ b/backend-configs/staging
@@ -1,0 +1,5 @@
+resource_group_name  = "tf-remote-state-datadog-staging-tFUCLB"
+storage_account_name = "datadogstagingtfuclb"
+container_name       = "datadogstagingtfuclb"
+client_id            = "37e0239c-662d-48b9-b5da-fc17d0ccfd30"
+# client_secret      = "" # Specified through the env. variable $TF_BACKEND_ARM_CLIENT_SECRET

--- a/backend.tf
+++ b/backend.tf
@@ -1,3 +1,7 @@
 terraform {
-  backend "azurerm" {}
+  backend "azurerm" {
+    subscription_id = "dff2ec18-6a8e-405c-8e45-b7df7465acf0"
+    tenant_id       = "4c45fef2-1ba7-4120-80a0-9e2d03e9c2b6"
+    key             = "terraform.tfstate"
+  }
 }

--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -36,7 +36,7 @@ resource "datadog_monitor" "build_report_stale" {
     Notify: @pagerduty
   EOT
 
-# Alert if any check in the last 5m reports stale (>=1) for this specific controller+job
+  # Alert if any check in the last 5m reports stale (>=1) for this specific controller+job
   query               = "max(last_5m):avg:jenkins.build_report.stale{controller:${each.value.controller},job:${each.value.job}} by {threshold_in_hours} >= 1"
   notify_audit        = false
   timeout_h           = 0


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/helpdesk/issues/5169#issuecomment-4622327077