### PR TITLE
refactor(build-reports): mirror kubernetes-management instances list

### DIFF
--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -6,9 +6,6 @@
 instances:
   ## infra.ci.jenkins.io jobs
   - controller: infra.ci.jenkins.io
-    job: docker-jobs/docker-404/main
-    threshold_minutes: 1440
-  - controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
   - controller: infra.ci.jenkins.io

--- a/build-report-jobs.yaml
+++ b/build-report-jobs.yaml
@@ -1,71 +1,60 @@
 # Build report jobs to monitor for staleness
+# Mirrors the instances list in kubernetes-management:
+# config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml
 # Ref: https://github.com/jenkins-infra/helpdesk/issues/2843
 
-build_report_jobs:
+instances:
   ## infra.ci.jenkins.io jobs
-  acceptance-tests-infra-ci:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
+    job: docker-jobs/docker-404/main
+    threshold_minutes: 1440
+  - controller: infra.ci.jenkins.io
     job: acceptance-tests/acceptance-tests/check-agent-availability
     threshold_minutes: 1440
-  kubernetes-management:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: kubernetes-jobs/kubernetes-management/main
     threshold_minutes: 1440
-  terraform-azure:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: terraform-jobs/azure/main
     threshold_minutes: 1440
-  terraform-azure-net:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: terraform-jobs/azure-net/main
     threshold_minutes: 1440
-  terraform-datadog:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: terraform-jobs/datadog/main
     threshold_minutes: 1440
-  terraform-digitalocean:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: terraform-jobs/digitalocean/main
     threshold_minutes: 1440
-  terraform-aws-sponsorship:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: terraform-jobs/terraform-aws-sponsorship/main
     threshold_minutes: 1440
-  ## release.ci.jenkins.io jobs
-  acceptance-tests-release-ci:
-    controller: release.ci.jenkins.io
-    job: infra-agents-health/master
-    threshold_minutes: 1440  # 1 day (1 build)
-  ## trusted.ci.jenkins.io jobs
-  acceptance-tests-trusted-ci:
-    controller: trusted.ci.jenkins.io
-    job: acceptance-tests-check-agent-availability
-    threshold_minutes: 1440
-  core-taglibs-report-generator:
-    controller: trusted.ci.jenkins.io
-    job: core-taglibs-report-generator
-    threshold_minutes: 10080  # 1 week (1 build)
-  crawler:
-    controller: trusted.ci.jenkins.io
-    job: crawler
-    threshold_minutes: 240  # 4 hours (1 build)
-  javadoc:
-    controller: trusted.ci.jenkins.io
-    job: javadoc
-    threshold_minutes: 10080  # 1 week (1 build)
-  jenkins-io:
-    controller: trusted.ci.jenkins.io
-    job: jenkins.io
-    threshold_minutes: 60  # (2 builds)
-  repository-permissions-updater:
-    controller: trusted.ci.jenkins.io
-    job: repository-permissions-updater
-    threshold_minutes: 360  # (2 builds)
-  update-center:
-    controller: trusted.ci.jenkins.io
-    job: update_center
-    threshold_minutes: 20  # (2 builds)
-  docs-jenkins-io:
-    controller: infra.ci.jenkins.io
+  - controller: infra.ci.jenkins.io
     job: website-production-jobs/docs.jenkins.io/main
     threshold_minutes: 1440
+  ## release.ci.jenkins.io jobs
+  - controller: release.ci.jenkins.io
+    job: infra-agents-health/master
+    threshold_minutes: 1440
+  ## trusted.ci.jenkins.io jobs
+  - controller: trusted.ci.jenkins.io
+    job: acceptance-tests-check-agent-availability
+    threshold_minutes: 1440
+  - controller: trusted.ci.jenkins.io
+    job: core-taglibs-report-generator
+    threshold_minutes: 10080  # 1 week (1 build)
+  - controller: trusted.ci.jenkins.io
+    job: crawler
+    threshold_minutes: 240  # 4 hours (1 build)
+  - controller: trusted.ci.jenkins.io
+    job: javadoc
+    threshold_minutes: 10080  # 1 week (1 build)
+  - controller: trusted.ci.jenkins.io
+    job: jenkins.io
+    threshold_minutes: 60  # (2 builds)
+  - controller: trusted.ci.jenkins.io
+    job: repository-permissions-updater
+    threshold_minutes: 360  # (2 builds)
+  - controller: trusted.ci.jenkins.io
+    job: update_center
+    threshold_minutes: 20  # (2 builds)

--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -6,7 +6,12 @@
 # Ref: https://github.com/jenkins-infra/helpdesk/issues/2843
 
 locals {
-  build_report_jobs = yamldecode(file("${path.module}/build-report-jobs.yaml")).build_report_jobs
+  # build-report-jobs.yaml mirrors the instances list in kubernetes-management.
+  # for_each requires a map, so key each instance by controller/job.
+  build_report_jobs = {
+    for inst in yamldecode(file("${path.module}/build-report-jobs.yaml")).instances :
+    "${inst.controller}/${inst.job}" => inst
+  }
 }
 
 resource "datadog_monitor" "build_report_stale" {


### PR DESCRIPTION
Ref:
- https://github.com/jenkins-infra/helpdesk/issues/2843

Companion to 
- jenkins-infra/kubernetes-management#7809.

Converge on a single canonical list structure shared with the buildReportStalenessCheck config in kubernetes-management, instead of maintaining a separate map here.

## Changes

- `build-report-jobs.yaml`: Converted from a `build_report_jobs` map to an `instances` list, mirroring the list in kubernetes-management(`config/publick8s/datadog_confd_checksd/buildReportStalenessCheck.yaml`).
- `monitor-build-reports.tf`: The `locals` block now converts the list into a map keyed by `controller/job` via a `for` expression, since `for_each`requires a map. Monitor definitions are otherwise unchanged.
