### PR TITLE
refactor(monitor-build-reports): key monitors by controller/job

### DIFF
--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -6,8 +6,12 @@
 # Ref: https://github.com/jenkins-infra/helpdesk/issues/2843
 
 locals {
-  build_report_jobs = yamldecode(file("${path.module}/build-report-jobs.yaml")).build_report_jobs
+  build_report_jobs = {
+    for name, job in yamldecode(file("${path.module}/build-report-jobs.yaml")).build_report_jobs :
+    "${job.controller}/${job.job}" => job
+  }
 }
+
 
 resource "datadog_monitor" "build_report_stale" {
   for_each = local.build_report_jobs


### PR DESCRIPTION
Split out from #366 per review feedback, so the key change is isolated from the YAML data-structure change.

The `for_each` key for the build-report monitors moves from the map entry name (e.g. `terraform-aws-sponsorship`) to `controller/job` (e.g.`infra.ci.jenkins.io/terraform-jobs/terraform-aws-sponsorship/main`).

Keying by `controller/job` matches the tags already used in the monitor queries and removes a latent collision: today two jobs sharing a name on different controllers would clash on the same map key.

Only the `locals` block in `monitor-build-reports.tf` changes, the monitor resource definitions are untouched.

Expected plan: destroy + recreate:

Because the `for_each` keys change, Terraform destroys each monitor at its old address and recreates it at the new `controller/job` address:

#Follow-up:

Once this merges, #366 will be rebased to switch the YAML from a map to the`instances` list (matching kubernetes-management) and should then introduce **no monitor changes**.
