### PR TITLE
fix(monitor-build-reports): use full Jenkins folder path in stale monitor Job URL

### DIFF
--- a/monitor-build-reports.tf
+++ b/monitor-build-reports.tf
@@ -26,7 +26,7 @@ resource "datadog_monitor" "build_report_stale" {
 
     - The build report for {{ job.name }} on {{ controller.name }} has not been updated in over {{ threshold_in_hours.name }} hour(s)
     - Check the job on the private controller {{ controller.name }}
-    - Job URL: https://{{ controller.name }}/job/{{ job.name }}
+    - Job URL: https://${each.value.controller}/job/${replace(each.value.job, "/", "/job/")}
     - Report: https://builds.reports.jenkins.io/build_status_reports/{{ controller.name }}/{{ job.name }}/status.json
 
     - https://github.com/jenkins-infra/helpdesk/issues/2843


### PR DESCRIPTION

Fix the Job URL in the build-report staleness monitor so it links to the correct Jenkins folder path.

`{{ job.name }}` holds the full folder path (e.g. `/reports/jira-users-report/main`), but the template only prefixed a single
`/job/`, producing a broken URL:

https://infra.ci.jenkins.io/job/reports/jira-users-report/main

correct URL: https://infra.ci.jenkins.io/job/reports/job/jira-users-report/job/main
